### PR TITLE
Add sslMode from schema

### DIFF
--- a/lib/clowder-common-ruby/types.rb
+++ b/lib/clowder-common-ruby/types.rb
@@ -199,6 +199,7 @@ module ClowderCommonRuby
         keys << :adminUsername
         keys << :adminPassword
         keys << :rdsCa
+        keys << :sslMode
       end
     end
   end


### PR DESCRIPTION
The schema introduced new `sslMode` for `DatabaseConfig`, add it to client lib.