### PR TITLE
change 'raise' to 'warn' on unkown keys so changes to clowder spec don't break parsing

### DIFF
--- a/bin/ruby_class_converter.rb
+++ b/bin/ruby_class_converter.rb
@@ -76,7 +76,7 @@ class RubyClassConverter
     init_function << "      raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))\n"
     init_function << "\n"
     init_function << "      attributes = attributes.each_with_object({}) do |(k, v), h|\n"
-    init_function << "        raise \"The input [\#{k}] is invalid\" unless valid_keys.include?(k.to_sym)\n"
+    init_function << "        warn \"The input [\#{k}] is invalid\" unless valid_keys.include?(k.to_sym)\n"
     init_function << "        h[k.to_sym] = v\n"
     init_function << "      end\n"
     init_function << "\n"

--- a/lib/clowder-common-ruby/types.rb
+++ b/lib/clowder-common-ruby/types.rb
@@ -17,7 +17,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -64,7 +64,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -86,7 +86,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -111,7 +111,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -140,7 +140,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -161,7 +161,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -183,7 +183,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -199,7 +199,6 @@ module ClowderCommonRuby
         keys << :adminUsername
         keys << :adminPassword
         keys << :rdsCa
-        keys << :sslMode
       end
     end
   end
@@ -211,7 +210,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -235,7 +234,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -264,7 +263,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -285,7 +284,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -308,7 +307,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 
@@ -331,7 +330,7 @@ module ClowderCommonRuby
       raise 'The input argument (attributes) must be a hash' if (!attributes || !attributes.is_a?(Hash))
 
       attributes = attributes.each_with_object({}) do |(k, v), h|
-        raise "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
+        warn "The input [#{k}] is invalid" unless valid_keys.include?(k.to_sym)
         h[k.to_sym] = v
       end
 

--- a/test.json
+++ b/test.json
@@ -1,4 +1,12 @@
 {
+    "metadata": {
+      "deployments": [
+        {
+          "name": "svc",
+          "image": "quay.io/not_us/test_ruby_app:1337"
+        }
+      ]
+    },
     "webPort": 8000,
     "metricsPort": 9000,
     "metricsPath": "/metrics",


### PR DESCRIPTION
Recently the clowdapp schema changed to add a `metadata` key, which stopped all of the sources-api pods from starting since the library would raise on an unsupported key.

Rather than just swallowing the error I just had it `warn` to STDERR instead. This way we do get warnings if the parsing isn't set up (the schema hasn't been updated yet on their end), but the parsing will go through and allow the pods to start. 