### PR TITLE
feat(CI): automatically push to rubygems upon version bump

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    branches:
+      - "master"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt install -y ruby-full
+          bundle install
+      - name: Publish gem
+        run: git diff --name-only HEAD~1 HEAD | grep lib/clowder-common-ruby/version.rb && bundle exec rake release
+        env:
+          GEM_HOST_API_KEY: "${{secrets.GEM_HOST_API_KEY}}"
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
If there's a change in the `version.rb` file, we can trigger a `rake release` automatically.