### PR TITLE
Fix incorrect loading of Settings

### DIFF
--- a/config/initializers/0_clowder_rails.rb
+++ b/config/initializers/0_clowder_rails.rb
@@ -1,6 +1,6 @@
 require 'clowder-common-ruby/rails_config'
 
-if ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
+if ClowderCommonRuby::Config.clowder_enabled?
   config = ClowderCommonRuby::RailsConfig.to_h
 
   if config.dig('tls_ca_path')

--- a/lib/clowder-common-ruby/version.rb
+++ b/lib/clowder-common-ruby/version.rb
@@ -1,3 +1,3 @@
 module ClowderCommonRuby
-  VERSION = '0.3.0'.freeze # Patch version is being automatically bumped
+  VERSION = '0.3.1'.freeze # Patch version is being automatically bumped
 end


### PR DESCRIPTION
When checking for the definition of `Settings` in the initializer file, settings are not loaded and the engine is not providing configuration to the app it is used in. 

Due to these reasons I am reverting the check for the definition of `Settings`.