### PR TITLE
Fix incorrect bundling of gem

### DIFF
--- a/clowder-common-ruby.gemspec
+++ b/clowder-common-ruby.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/RedHatInsights/clowder-common-ruby"
   spec.license       = "Apache-2.0"
 
-  spec.files = Dir["{bin,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md", "sync_config.sh", "test.json"]
+  spec.files = Dir["{bin,lib,config}/**/*", "LICENSE.txt", "Rakefile", "README.md", "sync_config.sh", "test.json"]
 end

--- a/config/initializers/0_clowder_rails.rb
+++ b/config/initializers/0_clowder_rails.rb
@@ -1,6 +1,6 @@
 require 'clowder-common-ruby/rails_config'
 
-if ClowderCommonRuby::Config.clowder_enabled?
+if ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
   config = ClowderCommonRuby::RailsConfig.to_h
 
   if config.dig('tls_ca_path')

--- a/lib/clowder-common-ruby/version.rb
+++ b/lib/clowder-common-ruby/version.rb
@@ -1,3 +1,3 @@
 module ClowderCommonRuby
-  VERSION = '0.3.1'.freeze # Patch version is being automatically bumped
+  VERSION = '0.3.2'.freeze # Patch version is being automatically bumped
 end


### PR DESCRIPTION
This PR addresses the incorrect bundling of the gem, so that it includes the initializer. 
Also, the check for the definition of `Settings` has been added again.