### PR TITLE
Ensure cert file env var is string

### DIFF
--- a/config/initializers/0_clowder_rails.rb
+++ b/config/initializers/0_clowder_rails.rb
@@ -4,7 +4,7 @@ if ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
   config = ClowderCommonRuby::RailsConfig.to_h.deep_stringify_keys
 
   if config.dig('tls_ca_path')
-    ENV['SSL_CERT_FILE'] = Rails.root.join('tmp', 'cacert.crt')
+    ENV['SSL_CERT_FILE'] = Rails.root.join('tmp', 'cacert.crt').to_s
 
     File.open(ENV['SSL_CERT_FILE'], 'w') do |f|
       f.write(File.read('/etc/pki/tls/certs/ca-bundle.crt'))

--- a/lib/clowder-common-ruby/version.rb
+++ b/lib/clowder-common-ruby/version.rb
@@ -1,3 +1,3 @@
 module ClowderCommonRuby
-  VERSION = '0.5.3'.freeze # Patch version is being automatically bumped
+  VERSION = '0.5.4'.freeze # Patch version is being automatically bumped
 end


### PR DESCRIPTION
As is, `Rails.root.join('tmp', 'cacert.crt')` will return a `Pathname` object [1].
In order to set `ENV['SSL_CERT_FILE']`, the value must be a string [2], meaning
we need to call `.to_s` [3] on the output of the `Pathname` in order for it to set
correctly, without erroring: `TypeError: no implicit conversion of Pathname into String`.

The initial PR to introduce this change [4] was extracted from a compliance PR [5]
where the value of `ENV['SSL_CERT_FILE']` was being explicitly set to a string.

[1] https://ruby-doc.org/3.1.2/exts/pathname/Pathname.html
[2] https://ruby-doc.org/3.1.2/ENV.html
[3] https://ruby-doc.org/3.1.2/exts/pathname/Pathname.html#method-i-to_s
[4] https://github.com/RedHatInsights/clowder-common-ruby/pull/32
[5] https://github.com/RedHatInsights/compliance-backend/pull/1664/files#diff-274fbb104eb7e6e64d378ecb4f260a28440db9fc32916c19337dae8aa46cf85aL14