### PR TITLE
chore: update ubuntu version in GH Action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,7 @@ name: Run Unit Tests
 jobs:
 
   testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source code
         uses: actions/checkout@v1


### PR DESCRIPTION
From March/April Ubuntu v20 based workflow will be unsupported by GH Actions, so we need to upgrade.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/