### PR TITLE
fix: ignore the vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/


### PR DESCRIPTION
This should fix CI so that it doesn't try to commit the gems installed in the `Setup Ruby and install gems` step.