### PR TITLE
fix: ignore the bundle folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/bundle
 /.yardoc
 /Gemfile.lock
 /_yardoc/
@@ -7,4 +8,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-/vendor/


### PR DESCRIPTION
The CI error is coming from `peter-evans/create-pull-request@v4`. See [a buggy run](https://github.com/RedHatInsights/clowder-common-ruby/actions/runs/15961186297/job/45044183600).

```
/usr/bin/git status --porcelain -unormal --
  ?? vendor/
```

This will hopefully fix the issue and allow us to update the clowder schema.