### PR TITLE
Update for latest schema

### DIFF
--- a/bin/schema.json
+++ b/bin/schema.json
@@ -16,12 +16,20 @@
                     "description": "Defines the public port that the app should be configured to listen on for API traffic.",
                     "type": "integer"
                 },
+                "h2cPrivatePort": {
+                    "description": "Defines the private H2C port that the app should be configured to listen on for H2C traffic.",
+                    "type": "integer"
+                },
+                "h2cPublicPort": {
+                    "description": "Defines the public H2C port that the app should be configured to listen on for H2C traffic.",
+                    "type": "integer"
+                },
                 "webPort": {
                     "description": "Deprecated: Use 'publicPort' instead.",
                     "type": "integer"
                 },
                 "tlsCAPath": {
-                    "description": "Defines the port CA path",
+                    "description": "Defines path to default CA certificate for TLS connections to other ClowdApps. Only populated when TLS is enabled for entire ClowdEnvironment.",
                     "type": "string"
                 },
                 "metricsPort": {
@@ -495,6 +503,18 @@
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
                 },
+                "h2cPort": {
+                    "description": "The H2C port of the dependent service.",
+                    "type": "integer"
+                },
+                "h2cTLSPort": {
+                    "description": "The H2C TLS port of the dependent service.",
+                    "type": "integer"
+                },
+                "tlsCAPath": {
+                    "description": "Defines path to CA certificate for TLS connections to this ClowdApp. If present, this should override use of default TLS CA path.",
+                    "type": "string"
+                },
                 "apiPath": {
                     "description": "The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)",
                     "type": "string"
@@ -539,6 +559,18 @@
                 "tlsPort": {
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
+                },
+                "h2cPort": {
+                    "description": "The H2C port of the dependent service.",
+                    "type": "integer"
+                },
+                "h2cTLSPort": {
+                    "description": "The H2C TLS port of the dependent service.",
+                    "type": "integer"
+                },
+                "tlsCAPath": {
+                    "description": "Defines path to CA certificate for TLS connections to this ClowdApp. If present, this should override use of default TLS CA path.",
+                    "type": "string"
                 }
             },
             "required": [

--- a/lib/clowder-common-ruby/types.rb
+++ b/lib/clowder-common-ruby/types.rb
@@ -45,6 +45,8 @@ module ClowderCommonRuby
       [].tap do |keys|
         keys << :privatePort
         keys << :publicPort
+        keys << :h2cPrivatePort
+        keys << :h2cPublicPort
         keys << :webPort
         keys << :tlsCAPath
         keys << :metricsPort
@@ -418,6 +420,9 @@ module ClowderCommonRuby
         keys << :port
         keys << :app
         keys << :tlsPort
+        keys << :h2cPort
+        keys << :h2cTLSPort
+        keys << :tlsCAPath
         keys << :apiPath
         keys << :apiPaths
       end
@@ -444,6 +449,9 @@ module ClowderCommonRuby
         keys << :port
         keys << :app
         keys << :tlsPort
+        keys << :h2cPort
+        keys << :h2cTLSPort
+        keys << :tlsCAPath
       end
     end
   end


### PR DESCRIPTION
Incorporates new features added to schema:

H2C port support: Added h2cPrivatePort and h2cPublicPort to AppConfig for HTTP/2 Cleartext traffic handling
Prometheus Gateway configuration: New PrometheusGatewayConfig class with hostname and port configuration in AppConfig
Enhanced TLS paths: Added tlsCAPath to both DependencyEndpoint and PrivateDependencyEndpoint for custom CA certificate paths per ClowdApp
Hash cache: Added hashCache field to AppConfig for configMap/secret hash tracking
H2C endpoint support: Added h2cPort and h2cTLSPort to dependency endpoint types